### PR TITLE
Add web3-bot to testground

### DIFF
--- a/github/testground/membership.json
+++ b/github/testground/membership.json
@@ -1,4 +1,7 @@
 {
+  "web3-bot": {
+    "role": "member"
+  },
   "AbominableSnowman730": {
     "role": "member"
   },

--- a/github/testground/repository_collaborator.json
+++ b/github/testground/repository_collaborator.json
@@ -28,6 +28,9 @@
     }
   },
   "testground": {
+    "web3-bot": {
+      "permission": "push"
+    },
     "Stebalien": {
       "permission": "push"
     },


### PR DESCRIPTION
Adding `web3-bot` to `testground` so that we can set up Unified CI in `testground`.