### PR TITLE
chore: add p-shahi

### DIFF
--- a/github/testground.yml
+++ b/github/testground.yml
@@ -19,6 +19,7 @@ members:
     - KatarinaKeti
     - LudiSistemas
     - mxinden
+    - p-shahi
     - StefanGajic
     - StefanMiletich
     - tinytb
@@ -283,5 +284,6 @@ teams:
         - galargh
         - laurentsenta
       member:
+        - p-shahi
         - tinytb
     privacy: closed


### PR DESCRIPTION
### Summary
Adding myself as a member.

### Why do you need this?
I want do a trial run of using ZenHub for managing roadmaps (useful for linking issues across GitHub organizations e.g. linking Testground tickets to libp2p ones.) ZenHub requires I have write access in order to create a workspace.

### What else do we need to know?
n/a

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
