### PR TITLE
grant celestia required access and clean up old permissions

### DIFF
--- a/github/testground.yml
+++ b/github/testground.yml
@@ -28,6 +28,8 @@ members:
 repositories:
   docs:
     archived: false
+    branch_protection:
+      master: {}
     default_branch: master
     description: Content for docs.testground.ai
     teams:
@@ -229,11 +231,20 @@ repositories:
   tg-cypress-test:
     archived: false
     branch_protection:
+      main: {}
       master: {}
     default_branch: main
     description: "Project where we attempt to connect cypress and Testground. "
     visibility: public
 teams:
+  admins:
+    description: testground admins
+    members:
+      maintainer:
+        - coryschwartz
+        - nonsense
+        - raulk
+    privacy: secret
   Alumni:
     members:
       member:
@@ -247,14 +258,6 @@ teams:
         - StefanGajic
         - StefanMiletich
     privacy: closed
-  admins:
-    description: testground admins
-    members:
-      maintainer:
-        - coryschwartz
-        - nonsense
-        - raulk
-    privacy: secret
   celestia:
     create_default_maintainer: false
     description: https://github.com/celestiaorg

--- a/github/testground.yml
+++ b/github/testground.yml
@@ -35,6 +35,8 @@ repositories:
         - admins
       maintain:
         - maintainers
+      push:
+        - celestia
     visibility: public
   github-mgmt:
     # WARN: push+ access here should be treated exactly as cautiosly as org admin role
@@ -64,9 +66,6 @@ repositories:
     archived: false
     branch_protection:
       master: {}
-    collaborators:
-      push:
-        - Stebalien
     default_branch: master
     description: Testground infrastructure - playbooks and scripts for setting up a
       Kubernetes cluster for Testground
@@ -87,25 +86,26 @@ repositories:
     archived: false
     branch_protection:
       master: {}
-    collaborators:
-      admin:
-        - brdji
-      push:
-        - bokimilinkovic
-        - StefanGajic
     default_branch: master
     description: Testground project with test plans and examples for the learning project
+    teams:
+      admin:
+        - admins
+      maintain:
+        - maintainers
     visibility: public
   learning-example:
     archived: false
     branch_protection:
       master: {}
-    collaborators:
-      admin:
-        - brdji
     default_branch: master
     description: An example project intended to help newcomers familiarize
       themselves with the Testground tool
+    teams:
+      admin:
+        - admins
+      maintain:
+        - maintainers
     visibility: public
   pl-infra-testground:
     archived: false
@@ -115,9 +115,6 @@ repositories:
     archived: false
     branch_protection:
       master: {}
-    collaborators:
-      admin:
-        - coryschwartz
     default_branch: master
     teams:
       admin:
@@ -126,7 +123,7 @@ repositories:
         - maintainers
     visibility: public
   pm:
-    archived: false
+    archived: true
     branch_protection:
       master: {}
     default_branch: master
@@ -141,9 +138,6 @@ repositories:
     archived: false
     branch_protection:
       master: {}
-    collaborators:
-      push:
-        - Stebalien
     default_branch: master
     description: "Testground: SDK for developing test plans in Go"
     teams:
@@ -151,20 +145,21 @@ repositories:
         - admins
       maintain:
         - maintainers
+      push:
+        - celestia
     visibility: public
   sdk-js:
     archived: false
     branch_protection:
       master: {}
-    collaborators:
-      admin:
-        - hacdias
     default_branch: master
     teams:
       admin:
         - admins
       maintain:
         - maintainers
+      push:
+        - celestia
     visibility: public
   sdk-rust:
     archived: false
@@ -176,14 +171,14 @@ repositories:
         - admins
       maintain:
         - maintainers
+      push:
+        - celestia
     visibility: public
   sync-service:
     archived: false
     branch_protection:
       master: {}
     collaborators:
-      admin:
-        - hacdias
       pull:
         - testgroundbot
     default_branch: master
@@ -192,12 +187,19 @@ repositories:
         - admins
       maintain:
         - maintainers
+      push:
+        - celestia
     visibility: public
   testground-github-action:
     archived: false
     branch_protection:
       master: {}
     default_branch: master
+    teams:
+      admin:
+        - admins
+      maintain:
+        - maintainers
     topics:
       - ipdx
     visibility: public
@@ -206,22 +208,8 @@ repositories:
     branch_protection:
       master: {}
     collaborators:
-      admin:
-        - coryschwartz
-        - raulk
       pull:
         - testgroundbot
-      push:
-        - achingbrain
-        - aschmahmann
-        - daviddias
-        - dirkmc
-        - gmasgras
-        - jacobheun
-        - lanzafame
-        - petar
-        - Stebalien
-        - vyzo
     default_branch: master
     description: 🧪 A platform for testing, benchmarking, and simulating distributed
       and p2p systems at scale.
@@ -230,7 +218,7 @@ repositories:
         - admins
       maintain:
         - maintainers
-      triage:
+      push:
         - celestia
     topics:
       - continuous-integration
@@ -242,13 +230,23 @@ repositories:
     archived: false
     branch_protection:
       master: {}
-    collaborators:
-      admin:
-        - brdji
     default_branch: main
     description: "Project where we attempt to connect cypress and Testground. "
     visibility: public
 teams:
+  Alumni:
+    members:
+      member:
+        - AbominableSnowman730
+        - bokimilinkovic
+        - brdji
+        - dektech
+        - Kale98
+        - KatarinaKeti
+        - LudiSistemas
+        - StefanGajic
+        - StefanMiletich
+    privacy: closed
   admins:
     description: testground admins
     members:


### PR DESCRIPTION
I'm granting Celestia team access to core testground repos as per transition statement.

I'm also cleaning up permissions while at it. 