### PR TITLE
chore: add jrmanes and smuu as celestia members in tg

### DIFF
--- a/github/testground.yml
+++ b/github/testground.yml
@@ -15,12 +15,14 @@ members:
     - brdji
     - coryschwartz
     - dektech
+    - jrmanes
     - hacdias
     - Kale98
     - KatarinaKeti
     - LudiSistemas
     - mxinden
     - p-shahi
+    - smuu
     - StefanGajic
     - StefanMiletich
     - sysrex
@@ -1068,6 +1070,8 @@ teams:
     members:
       member:
         - Bidon15
+        - jrmanes
+        - smuu
         - sysrex
     privacy: closed
   github-mgmt stewards:

--- a/github/testground.yml
+++ b/github/testground.yml
@@ -15,8 +15,8 @@ members:
     - brdji
     - coryschwartz
     - dektech
-    - jrmanes
     - hacdias
+    - jrmanes
     - Kale98
     - KatarinaKeti
     - LudiSistemas


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

Adding 2 team members of Celestia as maintainers to testground

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
